### PR TITLE
docs: update config example to include libreTranslate mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ It will generate a `i18n-populator.config.json` file that you can edit later in 
       "name": "bing"
     },
     {
+      "name": "openAI"
+    },
+    {
+      "name": "deepL"
+    },
+    {
       "name": "libreTranslate",
       "mirrors": ["http://127.0.0.1:5000", "http://localhost:5001"]
     }
@@ -150,16 +156,6 @@ It will generate a `i18n-populator.config.json` file that you can edit later in 
 ```
 
 - 📌 Note: You can define one or more mirrors for LibreTranslate. The system will automatically select one available at the time of performing the translations.
-
-#### 🔍 What is a mirror?
-
-A mirror is an alternative instance of a service (in this case, LibreTranslate). By including multiple mirrors, you can ensure:
-
-- Reduced response time (the system selects the fastest or available one)
-
-- Redundancy in case of failures
-
-- Better load distribution if you manage multiple projects or users
 
 ### Generating translations with one command
 

--- a/README.md
+++ b/README.md
@@ -134,19 +134,32 @@ It will generate a `i18n-populator.config.json` file that you can edit later in 
 ```json
 {
   "basePath": "example",
-  "translationEngines": ["google", "bing", "libreTranslate", "openAI", "deepL"],
-  "languages": [
+  "translationEngines": [
     {
-      "name": "en",
-      "files": ["en.json"]
+      "name": "google"
     },
     {
-      "name": "es",
-      "files": ["es.json"]
+      "name": "bing"
+    },
+    {
+      "name": "libreTranslate",
+      "mirrors": ["http://127.0.0.1:5000", "http://localhost:5001"]
     }
   ]
 }
 ```
+
+- 📌 Note: You can define one or more mirrors for LibreTranslate. The system will automatically select one available at the time of performing the translations.
+
+#### 🔍 What is a mirror?
+
+A mirror is an alternative instance of a service (in this case, LibreTranslate). By including multiple mirrors, you can ensure:
+
+- Reduced response time (the system selects the fastest or available one)
+
+- Redundancy in case of failures
+
+- Better load distribution if you manage multiple projects or users
 
 ### Generating translations with one command
 


### PR DESCRIPTION
The previous example in the README was outdated and did not show how to add mirrors for the libreTranslate engine.

This change updates the configuration example to include the new supported format, allowing multiple mirrors to be defined, which improves fault tolerance and scalability of the translation service.

Includes:

- Updated translationEngines example with mirrors

- Brief explanation of what a mirror is and why to use it