### PR TITLE
doc: add new templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: 🐛 Bug Report
+about: Found an issue? Help us fix it!
+title: "[BUG] Short description of the bug"
+labels: bug, triage
+assignees: ''
+---
+
+## Description
+A clear and concise description of the problem you are experiencing.
+
+## Reproduction Steps
+Provide the exact steps to reproduce the behavior.
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected Behavior
+Describe what you expected to happen.
+
+## Actual Behavior
+Describe what actually happened.
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.
+![Description of the image](URL_of_the_image_or_drag_and_drop_here)
+
+## Checklist:
+- [ ] I have searched for similar issues in existing issues.
+- [ ] I have provided clear and concise steps to reproduce the bug.
+- [ ] I have described the expected behavior and the actual behavior.
+- [ ] I have added screenshots if relevant.
+- [ ] I have checked that those changes don´t break any functionality.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,6 +16,12 @@ Provide the exact steps to reproduce the behavior.
 3. Scroll down to '....'
 4. See error
 
+## Type of change
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Automation
+
 ## Expected Behavior
 Describe what you expected to happen.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,6 +9,12 @@ assignees: ''
 ## Feature Description
 A clear and concise description of the improvement or new feature you'd like to see. What problem does it solve, or what value does it add?
 
+## Type of change
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Automation
+
 ## Use Cases
 Describe how this feature would be used. Who are the primary users, and how would they interact with it?
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: ✨ Feature Request
+about: Have an idea to make this project even better? Let´s try it!
+title: "[FEAT] Short description of the feature"
+labels: enhancement, triage
+assignees: ''
+---
+
+## Feature Description
+A clear and concise description of the improvement or new feature you'd like to see. What problem does it solve, or what value does it add?
+
+## Use Cases
+Describe how this feature would be used. Who are the primary users, and how would they interact with it?
+
+## Expected Benefits
+How do you believe this enhancement will benefit the project or its users?
+
+## Alternatives Considered
+Have you thought about other ways to achieve the same result? If so, describe them and why this option is better. (could be optional)
+
+## Additional Information
+Add any other context or screenshots that might be helpful in understanding the suggestion. (could be optional)


### PR DESCRIPTION
This pr was created in order to automatize and make easy for developers to create new issues on the repo. Was added two templates to create new issues (feature and bugs) in order to differentiate the issue type
